### PR TITLE
Remove test objects

### DIFF
--- a/src/fxcorrelator.py
+++ b/src/fxcorrelator.py
@@ -16,7 +16,6 @@ Created on Feb 28, 2013
 import logging
 import socket
 import time
-import sys
 
 import numpy
 import struct
@@ -39,6 +38,7 @@ use_xeng_sim = False
 
 THREADED_FPGA_OP = fpgautils.threaded_fpga_operation
 THREADED_FPGA_FUNC = fpgautils.threaded_fpga_function
+
 
 class FxCorrelator(Instrument):
     """
@@ -132,6 +132,9 @@ class FxCorrelator(Instrument):
             self.logger.info('Loading design information')
             THREADED_FPGA_FUNC(self.fhosts, timeout=5, target_function='get_system_information')
             THREADED_FPGA_FUNC(self.xhosts, timeout=5, target_function='get_system_information')
+
+        # remove test hardware from designs
+        utils.remove_test_objects(self)
 
         if program:
             # cal the qdr on all boards

--- a/src/fxcorrelator.py
+++ b/src/fxcorrelator.py
@@ -206,7 +206,9 @@ class FxCorrelator(Instrument):
     #                 qdr.qdr_cal(fail_hard=False, verbosity=2)
 
     def est_sync_epoch(self):
-        """Estimates the synchronisation epoch based on current F-engine timestamp, and the system time."""
+        """
+        Estimates the synchronisation epoch based on current F-engine timestamp, and the system time.
+        """
         self.logger.warn("Estimating synchronisation epoch...")
         # get current time from an f-engine
         mcnt_before = self.fhosts[0].get_local_time()
@@ -214,18 +216,25 @@ class FxCorrelator(Instrument):
         self.logger.info('Current f engine timetamp: %i' % mcnt_before)
         assert mcnt_before & 0xfff == 0, 'Bottom 12 bits of timestamp from f-engine are not zero?!'
 
-
     def time_from_mcnt(self, mcnt):
-        """Returns the unix time UTC equivalent to the board timestamp. Does NOT account for wrapping timestamps."""
-        if self.synchronisation_epoch<0:
+        """
+        Returns the unix time UTC equivalent to the board timestamp. Does
+        NOT account for wrapping timestamps.
+        """
+        if self.synchronisation_epoch < 0:
             self.est_sync_epoch()
         return self.synchronisation_epoch + (float(mcnt) / float(self.sample_rate_hz))
 
     def mcnt_from_time(self, time_seconds):
-        """Returns the board timestamp from a given UTC system time (seconds since Unix Epoch). Accounts for wrapping timestamps."""
-        if self.synchronisation_epoch<0:
+        """
+        Returns the board timestamp from a given UTC system time
+        (seconds since Unix Epoch). Accounts for wrapping timestamps.
+        """
+        if self.synchronisation_epoch < 0:
             self.est_sync_epoch()
-        return int((time_seconds - self.synchronisation_epoch)*self.sample_rate_hz)%(2**int(self.configd['FxCorrelator']['timestamp_bits']))
+        time_diff_from_synch_epoch = time_seconds - self.synchronisation_epoch
+        time_diff_in_samples = int(time_diff_from_synch_epoch * self.sample_rate_hz)
+        return time_diff_in_samples % (2**int(self.configd['FxCorrelator']['timestamp_bits']))
 
     def qdr_calibrate(self):
         """

--- a/src/fxcorrelator_xengops.py
+++ b/src/fxcorrelator_xengops.py
@@ -208,14 +208,14 @@ def xeng_vacc_sync(corr, vacc_load_time=None):
             'Cannot load at a time in the past. '
             'Need at least %2.2f seconds lead time. You asked for %s.%i, '
             'and it is now %s.%i.' % (
-                               min_ld_time,
-                               time.strftime('%H:%M:%S',time.gmtime(vacc_load_time)),
-                               (vacc_load_time-int(vacc_load_time))*100,
-                               time.strftime('%H:%M:%S',time.gmtime(t_now)),
-                               (t_now-int(t_now))*100) )
+                min_ld_time,
+                time.strftime('%H:%M:%S', time.gmtime(vacc_load_time)),
+                (vacc_load_time-int(vacc_load_time))*100,
+                time.strftime('%H:%M:%S', time.gmtime(t_now)),
+                (t_now-int(t_now))*100))
 
     corr.logger.info('xeng vaccs syncing at %s (in %2.2fs)'
-                     % (time.ctime(),vacc_load_time-time.time()) )
+                     % (time.ctime(), vacc_load_time-time.time()))
 
     # check if the vaccs need resetting
     vaccstat = THREADED_FPGA_FUNC(corr.xhosts, timeout=10,
@@ -326,7 +326,7 @@ def xeng_vacc_sync(corr, vacc_load_time=None):
                 raise RuntimeError('VACC did not trigger!')
     corr.logger.info('\tAll VACCs triggered correctly.')
 
-    #allow vacc to flush and correctly populate parity bits:
+    # allow vacc to flush and correctly populate parity bits:
     corr.logger.info('\tWaiting %2.2fs for an accumulation to flush, '
                      'to correctly populate parity bits.' %
                      xeng_get_acc_time(corr))
@@ -336,9 +336,9 @@ def xeng_vacc_sync(corr, vacc_load_time=None):
     THREADED_FPGA_FUNC(corr.xhosts, timeout=10,
                        target_function='clear_status')
 
-    #wait for a good accumulation to finish.
+    # wait for a good accumulation to finish.
     corr.logger.info('\tWaiting %2.2fs for an accumulation to flush '
-                     'before checking counters.'%xeng_get_acc_time(corr))
+                     'before checking counters.' % xeng_get_acc_time(corr))
     time.sleep(xeng_get_acc_time(corr)+0.2)
 
     corr.logger.info('\tChecking for errors & accumulations...')
@@ -378,10 +378,11 @@ def xeng_set_acc_time(corr, acc_time_s, vacc_resync=True):
     if use_xeng_sim:
         raise RuntimeError('That\'s not an option anymore.')
     else:
-        new_acc_len = (corr.sample_rate_hz * acc_time_s) /
-                       (corr.xeng_accumulation_len * corr.n_chans * 2.0)
+        new_acc_len = ((corr.sample_rate_hz * acc_time_s) /
+                       (corr.xeng_accumulation_len * corr.n_chans * 2.0))
         new_acc_len = round(new_acc_len)
         xeng_set_acc_len(corr, new_acc_len, vacc_resync)
+
 
 def xeng_get_acc_time(corr):
     """
@@ -389,6 +390,7 @@ def xeng_get_acc_time(corr):
     :return:
     """
     return (corr.xeng_accumulation_len * corr.accumulation_len * corr.n_chans * 2.0) / corr.sample_rate_hz
+
 
 def xeng_set_acc_len(corr, acc_len=None, vacc_resync=True):
     """

--- a/src/utils.py
+++ b/src/utils.py
@@ -164,6 +164,7 @@ def process_new_eq(eq):
         eqlist[ctr] = complex(eq)
     return eqlist
 
+
 class UnpackDengPacketCapture(object):
     def __init__(self, pcap_file_or_name):
         try:
@@ -236,5 +237,22 @@ class UnpackDengPacketCapture(object):
                         "packets dropped?")
 
         self.pcap_file.close()
-        return (sorted_time_keys, data)
+        return sorted_time_keys, data
 
+
+def remove_test_objects(corr_instance):
+    """
+    Any hardware device whose name starts with test_ must be removed from the
+    attribute list.
+    :param corr_instance:
+    :return:
+    """
+    from casperfpga import casperfpga as ccasperfpga
+    for hosts in [corr_instance.fhosts, corr_instance.xhosts]:
+        for host in hosts:
+            for container_ in ccasperfpga.CASPER_MEMORY_DEVICES.values():
+                    attr_container = getattr(host, container_['container'])
+                    for attr_name in attr_container.names():
+                        if attr_name.find('test_') == 0:
+                            attr_container.remove_attribute(attr_name)
+                            print 'removed', attr_name

--- a/src/utils.py
+++ b/src/utils.py
@@ -248,6 +248,7 @@ def remove_test_objects(corr_instance):
     :return:
     """
     from casperfpga import casperfpga as ccasperfpga
+    _changes_made = False
     for hosts in [corr_instance.fhosts, corr_instance.xhosts]:
         for host in hosts:
             for container_ in ccasperfpga.CASPER_MEMORY_DEVICES.values():
@@ -255,4 +256,6 @@ def remove_test_objects(corr_instance):
                     for attr_name in attr_container.names():
                         if attr_name.find('test_') == 0:
                             attr_container.remove_attribute(attr_name)
-                            print 'removed', attr_name
+                            _changes_made = True
+    if _changes_made:
+        LOGGER.info('One or more test_ devices were removed. Just so you know.')


### PR DESCRIPTION
So any object in the FPG with a name starting with 'test_' will be removed from the hosts attributes. Allows test devices to be compiled in without messing up automatic correlator operations.

@brickZA 