### PR TITLE
Logging fixes

### DIFF
--- a/scripts/corr2_sensor_servlet.py
+++ b/scripts/corr2_sensor_servlet.py
@@ -9,6 +9,7 @@ import katcp
 import signal
 from tornado.ioloop import IOLoop
 import tornado.gen
+import time
 
 from corr2 import sensors, sensors_periodic, fxcorrelator
 from corr2.utils import KatcpStreamHandler
@@ -102,6 +103,16 @@ if __name__ == '__main__':
         args.config = os.environ['CORR2INI']
     if args.config == '':
         raise RuntimeError('No config file.')
+
+    # Always log to file.
+    iname = os.environ["CORR2INI"]
+    start_time = str(time.time())
+    log_filename = '{}_{}_sensor_servlet.log'.format(iname.strip().replace(' ', '_'), start_time)
+    file_handler = logging.FileHandler("{}".format(log_filename))  # /var/log/corr/
+    file_handler.setLevel(logging.DEBUG)
+    file_handler.setFormatter(formatter)
+    corr2_sensors_logger.addHandler(file_handler)
+
 
     ioloop = IOLoop.current()
     sensor_server = Corr2SensorServer('127.0.0.1', args.port)

--- a/scripts/corr2_sensor_servlet.py
+++ b/scripts/corr2_sensor_servlet.py
@@ -68,7 +68,7 @@ if __name__ == '__main__':
                         default=1235, type=int,
                         help='bind to this port to receive KATCP messages')
     parser.add_argument('--log_level', dest='loglevel', action='store',
-                        default='FATAL', help='log level to set')
+                        default='DEBUG', help='log level to set')
     parser.add_argument('--log_format_katcp', dest='lfm', action='store_true',
                         default=False, help='format log messsages for katcp')
     parser.add_argument('--config', dest='config', type=str, action='store',
@@ -108,11 +108,10 @@ if __name__ == '__main__':
     iname = os.environ["CORR2INI"]
     start_time = str(time.time())
     log_filename = '{}_{}_sensor_servlet.log'.format(iname.strip().replace(' ', '_'), start_time)
-    file_handler = logging.FileHandler("{}".format(log_filename))  # /var/log/corr/
-    file_handler.setLevel(logging.DEBUG)
+    file_handler = logging.FileHandler("/var/log/corr/{}".format(log_filename))
+    file_handler.setLevel(logging.ERROR)
     file_handler.setFormatter(formatter)
     corr2_sensors_logger.addHandler(file_handler)
-
 
     ioloop = IOLoop.current()
     sensor_server = Corr2SensorServer('127.0.0.1', args.port)

--- a/src/corr2LogHandlers.py
+++ b/src/corr2LogHandlers.py
@@ -1,6 +1,7 @@
 import logging
 import termcolors
 import datetime
+import time
 import os
 
 from katcp import Message as KatcpMessage
@@ -225,11 +226,11 @@ class KatcpHandler(CasperLogHandlers.CasperConsoleHandler):
         message_name = 'log'
         # - LEVEL timestamp_ms name message
         # - LEVEL E {INFO, WARN, ERROR, FATAL}
-        formatted_datetime = datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S.%f')[:-4]
-        message_data = [message.levelname, formatted_datetime, message.name, message.msg]
-        # message_data = [self.format(message)]
-        
-        log_message = KatcpMessage(message_type, message_name, message_data)
+
+        time_now = str(time.time())
+        # "arguments" argument of KatcpMessage needs to be such a list.
+        message_data = [message.levelname, time_now, message.name, message.msg]
+        log_message = KatcpMessage(message_type, message_name, arguments=message_data)
         
         # self.sock.mass_inform(log_message)
         self.mass_inform_func(log_message)

--- a/src/corr2LogHandlers.py
+++ b/src/corr2LogHandlers.py
@@ -499,6 +499,9 @@ def get_instrument_loggers(corr_obj, group_name):
         # Silly dictionary doesn't keep order by default!
         # logger_group_keys = logger_group_dict.keys()
         
+        if corr_obj is None:  # i.e. if the instrument hasn't been initialised yet.
+            return None, None
+
         if group_name == '' or group_name == 'instrument':
             # Need to get all loggers
             instrument_loggers = []

--- a/src/corr2LogHandlers.py
+++ b/src/corr2LogHandlers.py
@@ -133,8 +133,7 @@ def getKatcpLogger(logger_name, mass_inform_func, log_level=logging.DEBUG, *args
     corr2_file_handler = logging.FileHandler(filename=full_log_file_path)
     corr2_file_handler.name = '{}_file'.format(logger_name)
 
-    formatted_datetime = datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S.%f')[:-4]
-    format_string = formatted_datetime + ' - %(levelname)s - %(name)s %(filename)s:%(lineno)s - %(msg)s'
+    format_string = '%(asctime)s - %(levelname)s - %(name)s %(filename)s:%(lineno)s - %(msg)s'
     file_handler_formatter = logging.Formatter(format_string)
     corr2_file_handler.setFormatter(file_handler_formatter)
 


### PR DESCRIPTION
Formatting of KatCP logs (CBFTASKS-706)
Log-level change for uninitialised instrument (CBFTASKS-716)
File-logging for sensor servlet (CBFTASKS-668)
Unchanging timestamp of logfile log messages (CBFTASKS-698)

Only thing that I'm not quite certain about is in commit 099e8a7 where I've hard-coded the directory where the log files should go to, I'm not sure that that's a good idea but I couldn't figure out how to set it up otherwise.