### PR TITLE
Adjust response timeouts for processing nodes

### DIFF
--- a/scripts/corr2_sensor_servlet.py
+++ b/scripts/corr2_sensor_servlet.py
@@ -120,6 +120,10 @@ class Corr2SensorServer(DeviceServer):
                                         log_filename=self.log_filename,
                                         log_file_dir=self.log_file_dir,
                                         logLevel=self.log_level)
+
+            # set response timeout
+            response_timeout = float(self.instrument.configd['FxCorrelator'].get('sensor_response_timeout', 0.1))
+            self.instrument._update_response_timeout(response_timeout)
             
             # Disable manually-issued sensor update informs (aka 'kcs' sensors):
             sensor_manager_inst = SensorManager(self, self.instrument,

--- a/src/fhost_fpga.py
+++ b/src/fhost_fpga.py
@@ -449,7 +449,8 @@ class FpgaFHost(FpgaHost):
         super(FpgaFHost, self).__init__(host=host, katcp_port=katcp_port,
                                         bitstream=bitstream,
                                         transport=SkarabTransport,
-                                        connect=connect)
+                                        connect=connect,
+                                        **kwargs)
 
         self._config = config
 

--- a/src/xhost_fpga.py
+++ b/src/xhost_fpga.py
@@ -15,7 +15,10 @@ class FpgaXHost(FpgaHost):
     def __init__(self, host, index, katcp_port=7147, bitstream=None,
                  connect=True, config=None, **kwargs):
         FpgaHost.__init__(self, host=host, katcp_port=katcp_port,
-                          bitstream=bitstream, connect=connect, transport=SkarabTransport)
+                          bitstream=bitstream, connect=connect,
+                          transport=SkarabTransport,
+                          **kwargs)
+
         try:
             descriptor = kwargs['descriptor']
         except KeyError:


### PR DESCRIPTION
A handful of changes that adjusts the response timeout when
communicating with processing nodes. The global response timeout for all
commands may now be adjusted across all processing nodes associated with
the instrument. At instrument initialisation, the global response
timeout defaults to min_load_time/2 (min_load_time is set in the config
files).

For the sensor servlet, the global response timeout is set via a new
parameter in the config files: "sensor_response_timeout". If this value
is not found in the config files, the response timeout defaults to
100 ms.

CBFTASKS-812